### PR TITLE
Import CommonModule instead of BrowserModule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from "@angular/forms";
-import { BrowserModule  } from '@angular/platform-browser';
+import { CommonModule  } from '@angular/common';
 
 import { Overlay } from './overlay';
 import { OverlayManager } from './overlay-manager';
@@ -13,7 +13,7 @@ export {
 };
 
 @NgModule({
-  imports: [ BrowserModule, FormsModule ],
+  imports: [ CommonModule, FormsModule ],
   declarations: [OverlayDirective],
   providers: [ OverlayManager ],
   exports: [ OverlayDirective ]


### PR DESCRIPTION
Changed to import CommonModule instead of BrowserModule so that this ng2-overlay can be used in lazy loaded modules.

Ref: https://github.com/ng2-ui/ng2-overlay/issues/1