### PR TITLE
fix(bug): prevent overlay shift position by setting parent position

### DIFF
--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -101,8 +101,8 @@ export class NguiOverlay {
         position: 'absolute',
         // backgroundColor: 'transparent',
         backgroundColor: 'rgba(0,0,0,0.2)',
-        top: parentEl.offsetTop + 'px',
-        left: parentEl.offsetLeft + 'px',
+        top: (!parentEl.style.position) ? parentEl.offsetTop + 'px' : '0px',
+        left: (!parentEl.style.position) ? parentEl.offsetLeft + 'px' : '0px',
         width: parentEl.offsetWidth + 'px',
         height: parentEl.offsetHeight + 'px'
       });


### PR DESCRIPTION
If parent element set position to `relative`, overlay position will shift.
![fireshot capture 41 - - http___localhost_9001_webpack-dev-server_](https://cloud.githubusercontent.com/assets/1610642/25940988/7b4829e8-366a-11e7-85b3-31c884e0d088.png)
